### PR TITLE
chore(build): pinning to ubuntu-20.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push]
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:
@@ -29,7 +29,7 @@ jobs:
 
   deploy_package:
     needs: build_and_test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v1
 


### PR DESCRIPTION
Per actions/virtual-environments#1816 `ubuntu-latest` workflows will use `ubuntu-20.04` so locking to a specific version for long term stability.